### PR TITLE
More details on integration of did:web and did:webs

### DIFF
--- a/spec/core.md
+++ b/spec/core.md
@@ -61,7 +61,9 @@ As with `did:web`, this method reads data from whatever web server is referenced
 when the domain name portion of one of its DIDs is resolved through the Domain
 Name System (DNS). In fact, a `did:webs` can be resolved to a [[ref: DID document]]
 using a simple text transformation to an HTTPS URL in the same way as a
-`did:web`. By design, a `did:web` and `did:webs` with the same [[ref: method-specific identifier]] will return the same DID document.
+`did:web`. By design, a `did:web` and `did:webs` with the same [[ref: method-specific identifier]] will return the same
+DID document, except for minor differences in the `id`, `controller`, and `alsoKnownAs` top-level properties that pertain
+to the identifiers themselves.
 
 However, this method introduces an important nuance about the target system. In
 many DID methods, the target system equals a [[ref: verifiable data registry]] —
@@ -216,40 +218,47 @@ DID-related documents have been copied.
 
 ### DID Method Operations
 
-#### Create (Register)
+#### Create
 
-Creating a DID involves these steps:
+Creating a `did:webs` DID involves the following steps:
 
-- Choose the web URL where the DID document for the DID will be published, excluding
-  the last element that will be the AID, once defined.
-- Create a KERI AID and add the appropriate KERI events that will (at least)
-  produce the DID document. That process is described in the [DID Document from KERI Events](#did-document-from-keri-events)
-  generation section of this specification.
-- Add the AID as the last element of the web URL for the DID.
-- Derive the DID document by processing the [[ref: KERI event stream]].
-- Create the AID folder on the web server at the selected location, and place
-the DID document and the [[ref: KERI event stream]] file into that folder.
+1. Choose the web URL where the DID document for the DID will be published, excluding
+   the last element that will be the AID, once defined.
+2. Create a KERI AID and add the appropriate KERI events that will correspond to
+   properties of the DID document, such as verification methods and service endpoints.
+3. Add the AID as the last element of the web URL for the DID.
+4. Derive the `did:webs` [[ref: DID document]] by processing the [[ref: KERI event stream]]
+   according to section [DID Document from KERI Events](#did-document-from-keri-events).
+5. Transform the derived `did:webs` DID document to the corresponding `did:web` DID document according
+   to section [Transformation to did:web DID Document](#transformation-to-didweb-did-document).
+6. Create the AID folder on the web server at the selected location, and place
+   the `did:web` DID document resource (`did.json`) and the [[ref: KERI event stream]] resource (`did.keri`)
+   into that folder. See section [Target System(s)](#target-systems) for further details about
+   the locations of these resources.
 
-Of course, the web server that serves the files when asked might be a simple
-file server (as implied above) or an active component that retrieves them
-dynamically. Further, the publisher of the files placed on the web can use
-capabilities like [CDNs] to distribute the files.
+Of course, the web server that serves the resources when asked might be a simple
+file server (as implied above) or an active component that generates them
+dynamically. Further, the publisher of the resources placed on the web can use
+capabilities like [CDNs] to distribute the resources.
 
 Likewise, an active component might be used by the controller of the DID to
-automate the process of publishing and updating the DID document and [[ref: KERI event stream]].
+automate the process of publishing and updating the DID document and [[ref: KERI event stream]] resources.
 
 #### Read (Resolve)
 
-Before a `did:webs` DID can undergo standard resolution, it must be converted
-back to an HTTPS URL [as described above](#method-specific-identifier). The
-reader then does a GET on both the URL for the DID document (ending in `/did.json`)
-and on the URL for the [[ref: KERI event stream]] (ending in `/did.keri`)
+Resolving a `did:webs` DID involves the following steps:
 
-On receipt of the two documents, the [[ref: KERI event stream]] is processed using [KERI Rules] to
-verify the validity of the [[ref: KERI event stream]] itself, and of the DID document.
+1. Convert the `did:webs` DID back to HTTPS URLs as described in section [Target System(s)](#target-systems).
+2. Execute HTTP GET requests on both the URL for the DID document (ending in `/did.json`)
+and the URL for the [[ref: KERI event stream]] (ending in `/did.keri`).
+3. Process the [[ref: KERI event stream]] using [KERI Rules] to verify it, then derive the `did:webs`
+   [[ref: DID document]] by processing the [[ref: KERI event stream]]
+   according to section [DID Document from KERI Events](#did-document-from-keri-events).
+4. Transform the retrieved `did:web` DID document to the corresponding `did:webs` DID document according
+   to section [Transformation to did:webs DID Document](#transformation-to-didwebs-did-document).
+5. Verify that the derived `did:webs` DID document (from step 3) equals the transformed DID document (from step 4).
 
-After retrieval, the [[ref: KERI event stream]] SHOULD BE processed using KERI rules by anyone
-resolving the DID document to verify its contents. Further, KERI-aware applications
+Further, KERI-aware applications
 MAY use the [[ref: KERI event stream]] to make use of additional capabilities enabled by the use of
 KERI. Capabilities beyond the verification of the DID document and [[ref: KERI event stream]] are outside
 the scope of this specification.

--- a/spec/diddocuments.md
+++ b/spec/diddocuments.md
@@ -277,6 +277,89 @@ Data structures similar to Location Scheme and Endpoint Authorizations and manag
 
 TODO:  Propose new data structures in KERI and Detail the transformation
 
+### Transformation to `did:web` DID Document
+
+The DID document that exists as a resource on a webserver is compatible with the `did:web` DID method and therefore
+necessarily different from a `did:webs` DID document with regard to the `id`, `controller`, and `alsoKnownAs` properties. This section
+defines a simple transformation algorithm from a `did:webs` DID document to a `did:web` DID document.
+
+Given a `did:webs` DID document, construct a new `did:web` DID document with the following differences:
+
+- In the values of the top-level `id` and `controller` properties of the DID document, replace the `did:webs` prefix string with `did:web`.
+- In the value of the top-level `alsoKnownAs` property, replace the entry that is now the new value of the `id` property (using `did:web`)
+  with the old value of the `id` property (using `did:webs`).
+- All other content of the DID document is simply copied without modifications.
+
+This transformation is used during the [Create](#create) DID method operation.
+
+For example, given the following `did:webs` DID document:
+```json
+{
+  "id": "did:webs:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+  "controller": "did:webs:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+  "alsoKnownAs": [
+    "did:web:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+    "did:webs:foo.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+    "did:keri:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M"
+  ],
+  ...
+}
+```
+
+The result of the transformation algorithm is the following `did:web` DID document:
+```json
+{
+  "id": "did:web:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+  "controller": "did:web:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+  "alsoKnownAs": [
+    "did:webs:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+    "did:webs:foo.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+    "did:keri:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M"
+  ],
+  ...
+}
+```
+
+### Transformation to `did:webs` DID Document
+
+This section defines an inverse transformation algorithm from a `did:web` DID document to a `did:webs` DID document.
+
+Given a `did:web` DID document, construct a new `did:webs` DID document with the following differences:
+
+- In the values of the top-level `id` and `controller` properties of the DID document, replace the `did:web` prefix string with `did:webs`.
+- In the value of the top-level `alsoKnownAs` property, replace the entry that is now the new value of the `id` property (using `did:webs`)
+  with the old value of the `id` property (using `did:web`).
+- All other content of the DID document is simply copied without modifications.
+
+This transformation is used during the [Read (Resolve)](#read-resolve) DID method operation.
+
+For example, given the following `did:web` DID document:
+```json
+{
+  "id": "did:web:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+  "controller": "did:web:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+  "alsoKnownAs": [
+    "did:webs:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+    "did:webs:foo.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+    "did:keri:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M"
+  ],
+  ...
+}
+```
+
+The result of the transformation algorithm is the following `did:webs` DID document:
+```json
+{
+  "id": "did:webs:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+  "controller": "did:webs:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+  "alsoKnownAs": [
+    "did:web:example.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+    "did:webs:foo.com:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M",
+    "did:keri:Ew-o5dU5WjDrxDBK4b4HrF82_rYb6MX6xsegjq4n0Y7M"
+  ],
+  ...
+}
+```
 
 ### Full Example
 The following blocks contain full annotated examples of a KERI AID with two events, an inception event and an interaction event, some witnesses, multiple public signing and rotation keys and an Agent with the resulting DID document that an implementation would generate assuming the implementation was running on the `example.com` domain with no unique port and no additional path defined:


### PR DESCRIPTION
This explains that the DID document resource on the web server is a `did:web` DID document, but the final resolved version is a `did:webs` DID document.

This adds sections with transformation algorithms between `did:web` and `did:webs` DID documents.

This also adds some details to the "Create" and "Read (Resolve)" DID method operations sections.

Fixes https://github.com/trustoverip/tswg-did-method-webs-specification/issues/30