### PR TITLE
Updated ABNF with expanded definition

### DIFF
--- a/spec/core.md
+++ b/spec/core.md
@@ -23,9 +23,28 @@ component of the path.
 
 The [[ref: ABNF]] definition of a `did:webs` DID is as follows:
 
-```
-webs-did = "did:webs:" host ":" aid
-webs-did = "did:webs:" host * (":" path) ":" aid
+```abnf
+webs-did = "did:webs:" host [pct-encoded-colon port] *(":" path) ":" aid
+
+; 'host' as defined in RFC 1035 and RFC 1123
+host = *( ALPHA / DIGIT / "-" / "." )  ; Simplified representation, actual RFCs
+                                       ; have more complex rules for domains and IP addresses.
+                                       ; IN ACTUAL IMPLEMENTATIONS REPLACE WITH A MATURE 
+                                       ; HOST PARSING LIBRARY.
+
+; 'pct-encoded-colon' represents a percent-encoded colon
+pct-encoded-colon = "%3A" / "%3a"  ; Percent encoding for ':'
+
+; 'port' number (simplified version)
+port = 1*5(DIGIT)
+
+; 'path' definition
+path = 1*(ALPHA / DIGIT / "-" / "_" / "~" / "." / "/")
+
+; 'aid' as base64 encoded value
+aid = 1*(ALPHA / DIGIT / "+" / "/" / "=") ; Base64 characters
+
+; ALPHA, DIGIT are standard ABNF primitives for alphabetic and numeric characters
 ```
 
 The formal rules describing valid [[ref: host]] syntax are described in


### PR DESCRIPTION
Updated ABNF with expanded definition.

Tested using https://author-tools.ietf.org/abnf  Should be able to copy/paste and get a parse.  Not tested beyond that.  

Questions for tomorrow:

1. Path is simplified version.  Big can of worms but better to be explicit now than figure it out later.  I know that `:` and a bunch of other crazy stuff can be in unix paths.  Maybe we should be explicit about what kinds of encodings we accept for elements of path if they want weird stuff. 
2. There is an `AID` definition that's stricter than what I've put right here based on the keripy (et al suite of tools) implementations.  However, this is just a particular construction of a class of AIDs (that I can imagine anyways and some that are mentioned in the keri whitepaper) and other implementations may be created in the future.  Keeping it vague may allow for weird stuff though.  I'll bring it up tomorrow on the talk because there's probably pros and cons to being more or less explicit.  