### PR TITLE
Linkable normative_references.md

### DIFF
--- a/spec/normative_references.md
+++ b/spec/normative_references.md
@@ -3,12 +3,32 @@
 
 ### Normative References
 
-* [Trust over IP - Authentic Chained Data Containers (ACDC) specification](https://trustoverip.github.io/tswg-acdc-specification/draft-ssmith-acdc.html)
-* [Trust over IP - Composable Event Streaming Representation (CESR)](https://trustoverip.github.io/tswg-cesr-specification/draft-ssmith-cesr.html)
-* [Trust over IP - CESR Proof Signatures](https://trustoverip.github.io/tswg-cesr-proof-specification/draft-pfeairheller-cesr-proof.html)
-* [Trust over IP - Issuance and Presentation Exchange (IPEX) Protocol](https://trustoverip.github.io/tswg-ipex-specification/draft-ssmith-ipex.html)
-* [Trust over IP - Key Event Receipt Infrastructure (KERI)](https://trustoverip.github.io/tswg-keri-specification/draft-ssmith-keri.html)
-* [Trust over IP - Out-of-Band-Introduction (OOBI) Protocol](https://trustoverip.github.io/tswg-oobi-specification/draft-ssmith-oobi.html)
-* [W3C - did:web Method Specification](https://w3c-ccg.github.io/did-method-web/)
-* [W3C - Decentralized Identifiers (DIDs)](https://www.w3.org/TR/did-core/)
-* [W3C - Verifiable Credentials Data Model (VCDM)](https://www.w3.org/TR/vc-data-model/)
+[[def: Trust over IP - Authentic Chained Data Containers (ACDC) specification, ACDC specification, ACDC protocol]]
+~ The [ACDC specification](https://trustoverip.github.io/tswg-acdc-specification/) details the core ACDC specification.
+
+[[def: Trust over IP - Composable Event Streaming Representation (CESR), CESR specification, CESR protocol]]
+~ The [CESR specification](https://trustoverip.github.io/tswg-cesr-specification/) details the core CESR protocol.
+
+[[def: Trust over IP - CESR Proof Signatures, CESR proof specification, CESR proof signatures, CESR proof protocol]]
+~ The [CESR Proof Signatures specification](https://trustoverip.github.io/tswg-cesr-proof-specification/draft-pfeairheller-cesr-proof.html) details the core CESR Proof Signatures.
+
+[[def: Trust over IP - Issuance and Presentation Exchange (IPEX) Protocol, ipex specification, ipex protocol]]
+~ The [IPEX specification](https://trustoverip.github.io/tswg-ipex-specification/) details the core Issuance and Presentation Exchange (IPEX) protocol.
+
+[[def: Trust over IP - Key Event Receipt Infrastructure (KERI), KERI specification, KERI specification, KERI protocol]]
+~ The [KERI specification](https://trustoverip.github.io/tswg-keri-specification/) details the core Key Event Receipt Infrastructure (KERI) protocol.
+
+[[def: Trust over IP - Out-of-Band-Introduction (OOBI) Protocol, oobi specification, oobi protocol]]
+~ The [OOBI specification](https://trustoverip.github.io/tswg-oobi-specification/) details the core Out-of-Band-Introduction (OOBI) protocol.
+
+[[def: Trust over IP - Self-Addressing IDentifier (SAID) specification, SAID specification, SAID protocol]]
+~ The [SAID specification](https://trustoverip.github.io/tswg-said-specification/) details the core Self-Addressing IDentifier (SAID) protocol.
+
+[[def: W3C - did:web Method Specification, did:web specification, did:web method]]
+~ The [did:web specification](https://w3c-ccg.github.io/did-method-web/) details the did:web method specification.
+
+[[def: W3C - Decentralized Identifiers (DIDs), did specification]]
+~ The [DIDs specification](https://w3c.github.io/did-core/) details the core Decentralized Identifiers (DIDs) specification.
+
+[[def: W3C - Verifiable Credentials Data Model (VCDM), vcdm specification]]
+~ The [W3C - Verifiable Credentials Data Model (VCDM)](https://www.w3.org/TR/vc-data-model/) details the the core Verifiable Credentials Data Model (VCDM) specification.

--- a/spec/normative_references.md
+++ b/spec/normative_references.md
@@ -21,5 +21,8 @@
 [[def: W3C - Decentralized Identifiers (DIDs), did specification]]
 ~ The [DIDs specification](https://w3c.github.io/did-core/) details the core Decentralized Identifiers (DIDs) specification.
 
+[[def: W3C - DID spec registries, DID spec registries, DID registry]]
+~ The [DID Spec Registries](https://w3c.github.io/did-spec-registries/) detail the specs for each registred DID method.
+
 [[def: W3C - Verifiable Credentials Data Model (VCDM), vcdm specification]]
 ~ The [W3C - Verifiable Credentials Data Model (VCDM)](https://www.w3.org/TR/vc-data-model/) details the the core Verifiable Credentials Data Model (VCDM) specification.

--- a/spec/normative_references.md
+++ b/spec/normative_references.md
@@ -4,25 +4,16 @@
 ### Normative References
 
 [[def: Trust over IP - Authentic Chained Data Containers (ACDC) specification, ACDC specification, ACDC protocol]]
-~ The [ACDC specification](https://trustoverip.github.io/tswg-acdc-specification/) details the core ACDC specification.
+~ The [ACDC specification](https://trustoverip.github.io/tswg-acdc-specification/) details the core ACDC specification including the Issuance and Presentation Exchange (IPEX) Protocol and Public Transaction Event Log (PTEL) specification.
 
 [[def: Trust over IP - Composable Event Streaming Representation (CESR), CESR specification, CESR protocol]]
-~ The [CESR specification](https://trustoverip.github.io/tswg-cesr-specification/) details the core CESR protocol.
+~ The [CESR specification](https://trustoverip.github.io/tswg-cesr-specification/) details the core CESR protocol including the Self-Addressing IDentifier (SAID) specification.
 
 [[def: Trust over IP - CESR Proof Signatures, CESR proof specification, CESR proof signatures, CESR proof protocol]]
 ~ The [CESR Proof Signatures specification](https://trustoverip.github.io/tswg-cesr-proof-specification/draft-pfeairheller-cesr-proof.html) details the core CESR Proof Signatures.
 
-[[def: Trust over IP - Issuance and Presentation Exchange (IPEX) Protocol, ipex specification, ipex protocol]]
-~ The [IPEX specification](https://trustoverip.github.io/tswg-ipex-specification/) details the core Issuance and Presentation Exchange (IPEX) protocol.
-
 [[def: Trust over IP - Key Event Receipt Infrastructure (KERI), KERI specification, KERI specification, KERI protocol]]
-~ The [KERI specification](https://trustoverip.github.io/tswg-keri-specification/) details the core Key Event Receipt Infrastructure (KERI) protocol.
-
-[[def: Trust over IP - Out-of-Band-Introduction (OOBI) Protocol, oobi specification, oobi protocol]]
-~ The [OOBI specification](https://trustoverip.github.io/tswg-oobi-specification/) details the core Out-of-Band-Introduction (OOBI) protocol.
-
-[[def: Trust over IP - Self-Addressing IDentifier (SAID) specification, SAID specification, SAID protocol]]
-~ The [SAID specification](https://trustoverip.github.io/tswg-said-specification/) details the core Self-Addressing IDentifier (SAID) protocol.
+~ The [KERI specification](https://trustoverip.github.io/tswg-keri-specification/) details the core Key Event Receipt Infrastructure (KERI) protocol. This includes the Out-of-Band-Introduction (OOBI) specification.
 
 [[def: W3C - did:web Method Specification, did:web specification, did:web method]]
 ~ The [did:web specification](https://w3c-ccg.github.io/did-method-web/) details the did:web method specification.


### PR DESCRIPTION
We have broken links and variety of links all over the spec docs, some of which have aged out, etc. This PR starts the process of consolidating normative reference links to one easy to maintain and reference section.